### PR TITLE
Feat/mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ printmaker <problem type> <option>
     - Generate integer addition and subtraction problems and answers in pdf format. You can specify the number of digits.
 - `matrix`
     - Generate matrix multiplication problems and answers in pdf format.
+- `mod`
+    - Generate division problems with a remainder and answers in pdf format.
 - `quadratic`
     - Generate quadratic equation problems and answers in pdf format.
 
@@ -43,6 +45,10 @@ printmaker <problem type> <option>
 
 #### `matrix`
 - `-d <int>`, `--dim <int>`      Dimension flag (default 3)
+
+#### `mod`
+- `-r`, `--left`         Number of left term digit
+- `-l`, `--right`        Number of right term digit
 
 #### `quadratic`
 - none
@@ -81,6 +87,16 @@ printmaker <problem type> <option>
 - Generate 300 2D matrix multiplication problems in 3 columns format.
     ```
     printmaker matrix --dim 2
+    ```
+
+- Generate 120 division problems with a remainderquadratic that the digit of left term is 3 and right term is 1 in 3 columns format.
+    ```
+    printmaker mod -s 120 --left 3 --right 1
+    ```
+
+- Generate 240 division problems with a remainderquadratic that the digit of left term is 5 and right term is 3 in 3 columns format.
+    ```
+    printmaker mod -s 240 -l 5 -r 3
     ```
 
 - Generate 200 quadratic equation problems in 3 columns format.

--- a/cmd/mod.go
+++ b/cmd/mod.go
@@ -1,0 +1,41 @@
+/*
+Copyright © 2024 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"printmaker/cmdhelper"
+
+	"github.com/spf13/cobra"
+)
+
+// modCmd represents the mod command
+var modCmd = &cobra.Command{
+	Use:   "mod",
+	Short: "Generate division problems with a remainder and answers in pdf format.",
+	Long: `Generate division problems with a remainder and answers in pdf format.
+For example:
+	Generate 300 division problems with a remainder in 2 columns format.
+	$printmaker mod --size 300 --column 2`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmdhelper.CmdMod(size, column, l, r)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(modCmd)
+	modCmd.Flags().IntVarP(&size, "size", "s", 100, "Size flag")
+	modCmd.Flags().IntVarP(&column, "column", "c", 3, "Column flag")
+	modCmd.Flags().IntVarP(&l, "left", "l", 2, "left digit")
+	modCmd.Flags().IntVarP(&r, "right", "r", 2, "right digit")
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// modCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// modCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmdhelper/mod.go
+++ b/cmdhelper/mod.go
@@ -1,0 +1,37 @@
+package cmdhelper
+
+import (
+	"fmt"
+	"printmaker/tex"
+	"printmaker/types"
+)
+
+func CmdMod(size int, column int, l int, r int) {
+	problems := generateModProblemList(size, l, r)
+	tex.GeneratePdf(problems, column)
+}
+
+func generateModProblemList(size int, l int, r int) []types.ProblemAnswer {
+	problems := make([]types.ProblemAnswer, size)
+	for i := 0; i < size; i++ {
+		problems[i] = generateModProblem(l, r)
+	}
+	return problems
+}
+
+func generateModProblem(l int, r int) types.ProblemAnswer {
+	a := generateDigitInteger(l)
+	b := generateDigitInteger(r)
+	if a < b {
+		a, b = b, a
+	}
+	return generateModAdditionSubtractionProblemAnswer(a, b)
+}
+
+func generateModAdditionSubtractionProblemAnswer(a int, b int) types.ProblemAnswer {
+	mod := a % b
+	quotient := a / b
+	problem := fmt.Sprint(a) + " \\div " + fmt.Sprint(b)
+	answer := fmt.Sprint(quotient) + " \\cdots " + fmt.Sprint(mod)
+	return types.ProblemAnswer{Problem: problem, Answer: answer}
+}

--- a/cmdhelper/mod.go
+++ b/cmdhelper/mod.go
@@ -32,6 +32,6 @@ func generateModAdditionSubtractionProblemAnswer(a int, b int) types.ProblemAnsw
 	mod := a % b
 	quotient := a / b
 	problem := fmt.Sprint(a) + " \\div " + fmt.Sprint(b)
-	answer := fmt.Sprint(quotient) + " \\cdots " + fmt.Sprint(mod)
+	answer := fmt.Sprint(quotient) + " あまり " + fmt.Sprint(mod)
 	return types.ProblemAnswer{Problem: problem, Answer: answer}
 }

--- a/cmdhelper/mod_test.go
+++ b/cmdhelper/mod_test.go
@@ -11,7 +11,7 @@ func TestGenerateModOk(t *testing.T) {
 	a := 43
 	b := 21
 	problem := "43 \\div 21"
-	answer := "2 \\cdots 1"
+	answer := "2 あまり 1"
 	expected := types.ProblemAnswer{Problem: problem, Answer: answer}
 
 	actual := generateModAdditionSubtractionProblemAnswer(a, b)

--- a/cmdhelper/mod_test.go
+++ b/cmdhelper/mod_test.go
@@ -1,0 +1,19 @@
+package cmdhelper
+
+import (
+	"printmaker/types"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateModOk(t *testing.T) {
+	a := 43
+	b := 21
+	problem := "43 \\div 21"
+	answer := "2 \\cdots 1"
+	expected := types.ProblemAnswer{Problem: problem, Answer: answer}
+
+	actual := generateModAdditionSubtractionProblemAnswer(a, b)
+	assert.Equal(t, expected, actual)
+}

--- a/tex/platex.go
+++ b/tex/platex.go
@@ -10,7 +10,7 @@ import (
 func GeneratePdf(problemList []types.ProblemAnswer, column int) {
 	content := platesSource(problemList, column)
 
-	baseFileName := "tmp"
+	baseFileName := "output"
 	tex := baseFileName + ".tex"
 	dvi := baseFileName + ".dvi"
 	aux := baseFileName + ".aux"


### PR DESCRIPTION
## 🔖 チケットへのリンク

- #9 

## ✨ やったこと

- 余りありの割り算問題を生成できるようにした
- 生成されるpdfファイルの名前をoutput.pdfに変更した

## 🔥 やらないこと

- 無し

## 🙆 できるようになること（ユーザ目線）

- 余りありの割り算問題を生成できるようになった

## 🙅 できなくなること（ユーザ目線）

- 無し

## 🚀 動作確認

- go testで確認
- pdfを生成して確認

## 👽️ その他

- 無し
